### PR TITLE
Mission_2WeekFix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### application-kakao.yml ###
 application-secret.yml
+
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' // 타임리프에서 layout.html 사용하려고
 }

--- a/records/2Week.LeeBuWon.md
+++ b/records/2Week.LeeBuWon.md
@@ -9,15 +9,18 @@
     - [x] case 4에서 똑같은 사유로 좋아요된 것에 한해서 예외처리 완료 후 case 6 실행
 
 ---
+
 ## 1주차 미션 요약
 
 ### [해결 방법]
 
 ### case 4
+
 - 1, 우선 fromInstaMember멤버의 username과 toInstaMember의 username을 repository에서 조회한다.
 - 2, repository에서 가져온 데이터를 isPresent() 이용하여 이미 존재한다면 RsData를 이용하여 fail을 던저준다.
 
 ### case 5
+
 - 1, 강사님이 layout에 주신 source 코드를 활용하여 접근하였습니다.
 - 2, member.getInstaMember().getFromLikeablePeople().size() 를 통하여 좋아요 한 숫자를 가져왔습니다.
 - 3, 좋아요한 숫자가 11이상이면 예외처리가 되도록 member.getInstaMember().getFromLikeablePeople().size() >= 11을 실행하게하였습니다.
@@ -25,12 +28,14 @@
 - 5, member.getInstaMember().getFromLikeablePeople().size() >= AppConfig.getLikeablePersonFromMax() 을 추가하여 해결하였다.
 
 ### case 6
+
 - 1, case 4를 기반으로 수정하여 isPresent()에서 존재한다면 existingLikeablePerson.get() 이용하여 정보를 가지고 온다.
 - 2, 가져온 정보를 updateLikeablePerson.setAttractiveTypeCode(attractiveTypeCode)을 이용하여 수정해준다. (현재는 사용하지 않는다. setter는 여러므로 단점이 많기 때문에..)
 - 3, 마지막으로 repository의 save()를 이용하여 저장해준다.
-- 4, Entity에서 Setter를 사용하지 않고 Getter만 이용하여 수정을 하게 해주기 위하여 update() 메서드를 만들어서 updateLikeablePerson.update(attractiveTypeCode) 이용하여 수정해준다. 
+- 4, Entity에서 Setter를 사용하지 않고 Getter만 이용하여 수정을 하게 해주기 위하여 update() 메서드를 만들어서 updateLikeablePerson.update(attractiveTypeCode) 이용하여 수정해준다.
 
 ### [리팩토링]
+
 - [x] setter를 이용한 의존성 주입방법은 단점이 많기 떄문에 getter만 이용하여 할 수 있도록 수정해준다.
 - [x] 현재는 case 6을 진행하면서 case 4를 사용하지 않게되었는데 AttractiveTypeCode를 이용하여 case 4를 활성화 해준다. 즉 같은 유형의 좋아요가 들어왔을 경우 case 4가 실행되게 해준다.
 - [ ] 현재 LikeablePseson의 like() 메서드가 너무 많은 것을 처리하여 수정 필요
@@ -39,8 +44,10 @@
 - [ ] N + 1 문제 해결
 
 ### [정리]
+
 - Setter를 사용하면 왜 안좋을까?
-  - 이유는 간단하다. Setter 메서드를 사용하면 값을 변경한 의도를 파악하기 힘들며 객체의 일관성을 유지하기 어렵기 때문이 대표적이다. 물론 그 외에도 다른 많은 단점들이 있겠지만 이정도만 해도 이유는 충분하다.
-  
+    - 이유는 간단하다. Setter 메서드를 사용하면 값을 변경한 의도를 파악하기 힘들며 객체의 일관성을 유지하기 어렵기 때문이 대표적이다. 물론 그 외에도 다른 많은 단점들이 있겠지만 이정도만 해도 이유는 충분하다.
+
 ### [참고한 사이트]
+
 - https://velog.io/@hope1213/Setter-%EC%82%AC%EC%9A%A9%EC%9D%84-%EC%99%9C-%EC%A7%80%EC%96%91%ED%95%B4%EC%95%BC%ED%95%A0%EA%B9%8C

--- a/records/2Week.LeeBuWon.md
+++ b/records/2Week.LeeBuWon.md
@@ -36,6 +36,7 @@
 - [ ] 현재 LikeablePseson의 like() 메서드가 너무 많은 것을 처리하여 수정 필요
 - [x] member.getInstaMember().getFromLikeablePeople().size() >= 10 하드코딩된 것을 yml파일로 이동
 - [ ] ServiceTest 작성
+- [ ] N + 1 문제 해결
 
 ### [정리]
 - Setter를 사용하면 왜 안좋을까?

--- a/src/main/java/com/ll/gramgram/base/BaseEntity.java
+++ b/src/main/java/com/ll/gramgram/base/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.ll.gramgram.base;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@MappedSuperclass
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@ToString
+public class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    @CreatedDate
+    private LocalDateTime createDate;
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+}

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -24,25 +24,29 @@ public class NotProd {
             Member memberUser2 = memberService.join("user2", "1234").getData();
             Member memberUser3 = memberService.join("user3", "1234").getData();
             Member memberUser4 = memberService.join("user4", "1234").getData();
+            Member memberUser5 = memberService.join("user5", "1234").getData();
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733187710").getData();
             Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__116152084938460177380").getData();
 
-            instaMemberService.connect(memberUser2, "bw1111", "M");
-            instaMemberService.connect(memberUser3, "bw2222", "W");
-            instaMemberService.connect(memberUser4, "bw3333", "M");
-            instaMemberService.connect(memberUser5ByKakao, "bw1611", "M");
+            instaMemberService.connect(memberUser2, "insta_user2", "M");
+            instaMemberService.connect(memberUser3, "insta_user3", "W");
+            instaMemberService.connect(memberUser4, "insta_user4", "M");
+            instaMemberService.connect(memberUser5, "insta_user5", "W");
 
-            likeablePersonService.like(memberUser5ByKakao, "bw1111", 1);
-            likeablePersonService.like(memberUser5ByKakao, "bw2222", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw3333", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw4444", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw5555", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw6666", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw7777", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw8888", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw9999", 2);
-            likeablePersonService.like(memberUser3, "bw1611", 2);
+            likeablePersonService.like(memberUser3, "insta_user4", 1);
+            likeablePersonService.like(memberUser3, "insta_user100", 2);
+
+            likeablePersonService.like(memberUser5, "insta_user101", 2);
+            likeablePersonService.like(memberUser5, "insta_user102", 2);
+            likeablePersonService.like(memberUser5, "insta_user103", 2);
+            likeablePersonService.like(memberUser5, "insta_user104", 2);
+            likeablePersonService.like(memberUser5, "insta_user105", 2);
+            likeablePersonService.like(memberUser5, "insta_user106", 2);
+            likeablePersonService.like(memberUser5, "insta_user107", 2);
+            likeablePersonService.like(memberUser5, "insta_user108", 2);
+            likeablePersonService.like(memberUser5, "insta_user109", 2);
+            likeablePersonService.like(memberUser5, "insta_user110", 2);
         };
     }
 }

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -42,7 +42,7 @@ public class NotProd {
             likeablePersonService.like(memberUser5ByKakao, "bw7777", 2);
             likeablePersonService.like(memberUser5ByKakao, "bw8888", 2);
             likeablePersonService.like(memberUser5ByKakao, "bw9999", 2);
-            likeablePersonService.like(memberUser5ByKakao, "bw1010", 2);
+            likeablePersonService.like(memberUser3, "bw1611", 2);
         };
     }
 }

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -28,6 +28,7 @@ public class NotProd {
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733187710").getData();
             Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__116152084938460177380").getData();
+            Member memberUser6Naver = memberService.whenSocialLogin("NAVER", "NAVER__ophv2uC5MZEYHDvUb7zljwLbZkkecD4Ts5LXfEQmq0g").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
+++ b/src/main/java/com/ll/gramgram/base/jpa/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.ll.gramgram.base.jpa;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/gramgram/base/security/CustomOAuth2UserService.java
@@ -29,9 +29,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        String oauthId = oAuth2User.getName();
-
         String providerTypeCode = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
+
+        String oauthId = switch (providerTypeCode) {
+            case "NAVER" -> ((Map<String, String>) oAuth2User.getAttributes().get("response")).get("id");
+            default -> oAuth2User.getName();
+        };
 
         String username = providerTypeCode + "__%s".formatted(oauthId);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/controller/InstaMemberController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/controller/InstaMemberController.java
@@ -46,7 +46,7 @@ public class InstaMemberController {
     public String connect(@Valid ConnectForm connectForm) {
         RsData<InstaMember> rsData = instaMemberService.connect(rq.getMember(), connectForm.getUsername(), connectForm.getGender());
 
-        if ( rsData.isFail() ) {
+        if (rsData.isFail()) {
             return rq.historyBack(rsData);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.instaMember.entity;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,21 +17,14 @@ import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@ToString
+@ToString(callSuper = true)
 @Entity
 @Getter
-public class InstaMember {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
+public class InstaMember extends BaseEntity {
     @Column(unique = true)
     private String username;
     @Setter
@@ -53,5 +48,13 @@ public class InstaMember {
 
     public void addToLikeablePerson(LikeablePerson likeablePerson) {
         toLikeablePeople.add(0, likeablePerson);
+    }
+
+    public void removeFromLikeablePerson(LikeablePerson likeablePerson) {
+        fromLikeablePeople.removeIf(e -> e.equals(likeablePerson));
+    }
+
+    public void removeToLikeablePerson(LikeablePerson likeablePerson) {
+        toLikeablePeople.removeIf(e -> e.equals(likeablePerson));
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -41,6 +41,14 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
+        RsData canLikeRsData = likeablePersonService.canLike(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
+
+        if (canLikeRsData.isFail()) {
+            return rq.historyBack(canLikeRsData);
+        }
+
+
+
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
         if (createRsData.isFail()) {
@@ -65,19 +73,6 @@ public class LikeablePersonController {
         return "usr/likeablePerson/list";
     }
 
-//    @PreAuthorize("isAuthenticated()")
-//    @GetMapping("/delete/{likeableId}")
-//    public String deleteLikeablePerson(@PathVariable Long likeableId){
-//        //TODO: likeablePerson 아이디를 통해 삭제하며, InstaMemberId가 일치해야만 삭제 가능
-//        log.info("likeablePerson 삭제 시작");
-//        RsData<LikeablePerson> removeRsData = likeablePersonService.deleteLikeablePerson(likeableId, rq.getMember().getInstaMember(), rq.getMember().getInstaMember().getId());
-//        if (removeRsData.isFail()){
-//            return rq.historyBack(removeRsData);
-//        }
-//
-//        return rq.redirectWithMsg("/likeablePerson/list", removeRsData);
-//    }
-
     /**
      * V2
      */
@@ -87,7 +82,7 @@ public class LikeablePersonController {
         log.info("delete 시작");
         LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        RsData canActorDeleteRsData = likeablePersonService.canActorDelete(rq.getMember(), likeablePerson);
+        RsData canActorDeleteRsData = likeablePersonService.canDelete(rq.getMember(), likeablePerson);
 
         if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -41,20 +41,7 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
-        RsData canLikeRsData = likeablePersonService.canLike(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
-
-        if (canLikeRsData.isFail()) {
-            return rq.historyBack(canLikeRsData);
-        }
-
-        RsData rsData = null;
-
-        if (canLikeRsData.getResultCode().equals("S-2")){
-            rsData = likeablePersonService.modifyAttractive(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
-        }
-        else {
-            rsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
-        }
+        RsData<LikeablePerson> rsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
 
         if (rsData.isFail()) {
             return rq.historyBack(rsData);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -47,15 +47,20 @@ public class LikeablePersonController {
             return rq.historyBack(canLikeRsData);
         }
 
+        RsData rsData = null;
 
-
-        RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
-
-        if (createRsData.isFail()) {
-            return rq.historyBack(createRsData);
+        if (canLikeRsData.getResultCode().equals("S-2")){
+            rsData = likeablePersonService.modifyAttractive(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
+        }
+        else {
+            rsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
         }
 
-        return rq.redirectWithMsg("/likeablePerson/list", createRsData);
+        if (rsData.isFail()) {
+            return rq.historyBack(rsData);
+        }
+
+        return rq.redirectWithMsg("/likeablePerson/list", rsData);
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.likeablePerson.entity;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,21 +13,12 @@ import java.time.LocalDateTime;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder
+@SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
-@ToString
+@ToString(callSuper = true)
 @Entity
 @Getter
-public class LikeablePerson {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
+public class LikeablePerson extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY) // Eager -> Lazy
     @ToString.Exclude
@@ -47,7 +40,7 @@ public class LikeablePerson {
         };
     }
 
-    public void update(int attractiveTypeCode){
+    public void update(int attractiveTypeCode) {
         this.attractiveTypeCode = attractiveTypeCode;
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -27,12 +27,12 @@ public class LikeablePerson {
     @LastModifiedDate
     private LocalDateTime modifyDate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY) // Eager -> Lazy
     @ToString.Exclude
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)
     private String fromInstaMemberUsername; // 혹시 몰라서 기록
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @ToString.Exclude
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -18,5 +18,5 @@ public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, 
 
     LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(long id, String instaUsername);
 
-    LikeablePerson findByFromInstaMember_usernameAndToInstaMember_username(String bw2222, String bw1611);
+    Optional<LikeablePerson> findByFromInstaMember_usernameAndToInstaMember_username(String fromInstaMemberUsername, String toInstaMemberUsername);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -3,7 +3,6 @@ package com.ll.gramgram.boundedContext.likeablePerson.repository;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,5 +17,6 @@ public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, 
     List<LikeablePerson> findByToInstaMember_username(String instaUsername);
 
     LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(long id, String instaUsername);
+
     LikeablePerson findByFromInstaMember_usernameAndToInstaMember_username(String bw2222, String bw1611);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long>, LikeablePersonRepositoryCustom  {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
 
     Optional<LikeablePerson> findByFromInstaMemberAndToInstaMember(InstaMember fromInstaMember, InstaMember toInstaMember);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -3,6 +3,7 @@ package com.ll.gramgram.boundedContext.likeablePerson.repository;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,7 +15,8 @@ public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, 
 
     Optional<LikeablePerson> findByFromInstaMemberAndToInstaMemberAndAttractiveTypeCode(InstaMember fromInstaMember, InstaMember toInstaMember, int AttractiveTypeCode);
 
-    LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(long id, String instaUsername);
-
     List<LikeablePerson> findByToInstaMember_username(String instaUsername);
+
+    LikeablePerson findByFromInstaMemberIdAndToInstaMember_username(long id, String instaUsername);
+    LikeablePerson findByFromInstaMember_usernameAndToInstaMember_username(String bw2222, String bw1611);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+
+import java.util.Optional;
+
+public interface LikeablePersonRepositoryCustom {
+
+    Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.ll.gramgram.boundedContext.likeablePerson.repository;
+
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
+
+@RequiredArgsConstructor
+public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .selectFrom(likeablePerson)
+                        .where(
+                                likeablePerson.fromInstaMember.id.eq(fromInstaMemberId)
+                                        .and(
+                                                likeablePerson.toInstaMember.username.eq(toInstaMemberUsername)
+                                        )
+                        )
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -57,7 +57,7 @@ public class LikeablePersonService {
         log.info("member.getInstaMember().getFromLikeablePeople().size() = {}", member.getInstaMember().getFromLikeablePeople().size());
 
         if (member.getInstaMember().getFromLikeablePeople().size() >= AppConfig.getLikeablePersonFromMax()) {
-            return RsData.of("F-4", "좋아요 한 사람은 %d명을 넘길 수 없습니다.". formatted(AppConfig.getLikeablePersonFromMax())); // 하드 코딩된 숫자를 max변경에 따라 변하게 수정
+            return RsData.of("F-4", "좋아요 한 사람은 %d명을 넘길 수 없습니다.".formatted(AppConfig.getLikeablePersonFromMax())); // 하드 코딩된 숫자를 max변경에 따라 변하게 수정
         }
 
         LikeablePerson likeablePerson = LikeablePerson
@@ -90,6 +90,12 @@ public class LikeablePersonService {
 
     @Transactional
     public RsData delete(LikeablePerson likeablePerson) {
+        // 너가 생성한 좋아요가 사라졌어.
+        likeablePerson.getFromInstaMember().removeFromLikeablePerson(likeablePerson);
+
+        // 너가 받은 좋아요가 사라졌어.
+        likeablePerson.getToInstaMember().removeToLikeablePerson(likeablePerson);
+
         likeablePersonRepository.delete(likeablePerson);
 
         String likeCanceledUsername = likeablePerson.getToInstaMember().getUsername();

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -49,8 +49,7 @@ public class LikeablePersonService {
         if (existingLikeablePerson.isPresent()) {
             LikeablePerson updateLikeablePerson = existingLikeablePerson.get(); // 1, 정보를 가져온다.
             updateLikeablePerson.update(attractiveTypeCode); // 2, set -> get으로 업데이트 수정
-            likeablePersonRepository.save(updateLikeablePerson); // 3, 다시 저장해준다.
-
+            // Save가 없더라도 영속성 컨텍스트에서 관리되는 엔티디는 자동으로 갱신이 된다.
             return RsData.of("S-2", "입력하신 인스타유저(%s)의 호감유형을 수정하였습니다.".formatted(username), updateLikeablePerson);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -117,15 +117,15 @@ public class LikeablePersonService {
             return RsData.of("F-3", "이미 %s님에 대해서 호감표시를 했습니다.".formatted(username));
         }
 
+        if (fromLikeablePerson != null){
+            return RsData.of("S-2", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));
+        }
+
         //TODO: case 5 - 좋아요 목록의 사람이 10명이 넘어가면 에러메시지 출력
         long likeablePersonFromMax = AppConfig.getLikeablePersonFromMax();
 
         if ( fromLikeablePeople.size() >= likeablePersonFromMax){
             return RsData.of("F-4", "최대 %d명에 대해서만 호감표시가 가능합니다.".formatted(likeablePersonFromMax));
-        }
-
-        if (fromLikeablePerson != null){
-            return RsData.of("S-2", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));
         }
 
         return RsData.of("S-1", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -57,7 +57,7 @@ public class LikeablePersonService {
         log.info("member.getInstaMember().getFromLikeablePeople().size() = {}", member.getInstaMember().getFromLikeablePeople().size());
 
         if (member.getInstaMember().getFromLikeablePeople().size() >= AppConfig.getLikeablePersonFromMax()) {
-            return RsData.of("F-4", "좋아요 한 사람은 10명을 넘길 수 없습니다.");
+            return RsData.of("F-4", "좋아요 한 사람은 %d명을 넘길 수 없습니다.". formatted(AppConfig.getLikeablePersonFromMax())); // 하드 코딩된 숫자를 max변경에 따라 변하게 수정
         }
 
         LikeablePerson likeablePerson = LikeablePerson
@@ -94,6 +94,7 @@ public class LikeablePersonService {
 
         String likeCanceledUsername = likeablePerson.getToInstaMember().getUsername();
         return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(likeCanceledUsername));
+
     }
 
     public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -38,27 +38,27 @@ public class LikeablePersonService {
         log.info("toInstaMember = {}", toInstaMember);
         log.info("attractiveTypeCode = {}", attractiveTypeCode);
 
-        //TODO: case 4 - 이미 좋아요 된 사람에게 또 좋아요하는 것을 방지하는 로직
-        Optional<LikeablePerson> existingLikeablePersonData = likeablePersonRepository.findByFromInstaMemberAndToInstaMemberAndAttractiveTypeCode(fromInstaMember, toInstaMember, attractiveTypeCode);
-        if (existingLikeablePersonData.isPresent()) {
-            return RsData.of("F-3", "이미 좋아요된 사람에게는 같은 호감유형으로 좋아요 추가할 수 없습니다.");
-        }
-
-        //TODO: case 6 - 케이스 4 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리한다.
-        Optional<LikeablePerson> existingLikeablePerson = likeablePersonRepository.findByFromInstaMemberAndToInstaMember(fromInstaMember, toInstaMember);
-        if (existingLikeablePerson.isPresent()) {
-            LikeablePerson updateLikeablePerson = existingLikeablePerson.get(); // 1, 정보를 가져온다.
-            updateLikeablePerson.update(attractiveTypeCode); // 2, set -> get으로 업데이트 수정
-            // Save가 없더라도 영속성 컨텍스트에서 관리되는 엔티디는 자동으로 갱신이 된다.
-            return RsData.of("S-2", "입력하신 인스타유저(%s)의 호감유형을 수정하였습니다.".formatted(username), updateLikeablePerson);
-        }
-
-        //TODO: case 5 - 좋아요 목록의 사람이 10명이 넘어가면 에러메시지 출력
-        log.info("member.getInstaMember().getFromLikeablePeople().size() = {}", member.getInstaMember().getFromLikeablePeople().size());
-
-        if (member.getInstaMember().getFromLikeablePeople().size() >= AppConfig.getLikeablePersonFromMax()) {
-            return RsData.of("F-4", "좋아요 한 사람은 %d명을 넘길 수 없습니다.".formatted(AppConfig.getLikeablePersonFromMax())); // 하드 코딩된 숫자를 max변경에 따라 변하게 수정
-        }
+//        //TODO: case 4 - 이미 좋아요 된 사람에게 또 좋아요하는 것을 방지하는 로직
+//        Optional<LikeablePerson> existingLikeablePersonData = likeablePersonRepository.findByFromInstaMemberAndToInstaMemberAndAttractiveTypeCode(fromInstaMember, toInstaMember, attractiveTypeCode);
+//        if (existingLikeablePersonData.isPresent()) {
+//            return RsData.of("F-3", "이미 좋아요된 사람에게는 같은 호감유형으로 좋아요 추가할 수 없습니다.");
+//        }
+//
+//        //TODO: case 6 - 케이스 4 가 발생했을 때 기존의 사유와 다른 사유로 호감을 표시하는 경우에는 성공으로 처리한다.
+//        Optional<LikeablePerson> existingLikeablePerson = likeablePersonRepository.findByFromInstaMemberAndToInstaMember(fromInstaMember, toInstaMember);
+//        if (existingLikeablePerson.isPresent()) {
+//            LikeablePerson updateLikeablePerson = existingLikeablePerson.get(); // 1, 정보를 가져온다.
+//            updateLikeablePerson.update(attractiveTypeCode); // 2, set -> get으로 업데이트 수정
+//            // Save가 없더라도 영속성 컨텍스트에서 관리되는 엔티디는 자동으로 갱신이 된다.
+//            return RsData.of("S-2", "입력하신 인스타유저(%s)의 호감유형을 수정하였습니다.".formatted(username), updateLikeablePerson);
+//        }
+//
+//        //TODO: case 5 - 좋아요 목록의 사람이 10명이 넘어가면 에러메시지 출력
+//        log.info("member.getInstaMember().getFromLikeablePeople().size() = {}", member.getInstaMember().getFromLikeablePeople().size());
+//
+//        if (member.getInstaMember().getFromLikeablePeople().size() >= AppConfig.getLikeablePersonFromMax()) {
+//            return RsData.of("F-4", "좋아요 한 사람은 %d명을 넘길 수 없습니다.".formatted(AppConfig.getLikeablePersonFromMax())); // 하드 코딩된 숫자를 max변경에 따라 변하게 수정
+//        }
 
         LikeablePerson likeablePerson = LikeablePerson
                 .builder()
@@ -103,7 +103,7 @@ public class LikeablePersonService {
 
     }
 
-    public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {
+    public RsData canDelete(Member actor, LikeablePerson likeablePerson) {
         if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
 
         // 수행자의 인스타계정 번호
@@ -117,4 +117,40 @@ public class LikeablePersonService {
         return RsData.of("S-1", "삭제가능합니다.");
     }
 
+    public RsData canLike(Member actor, String username, int attractiveTypeCode) {
+        if (!actor.hasConnectedInstaMember()){
+            return RsData.of("F-1", "먼저 본인의 인스타그램 아이디를 입력해주세요");
+        }
+
+        InstaMember fromInstaMember = actor.getInstaMember();
+
+        if (fromInstaMember.getUsername().equals(username)){
+            return RsData.of("F-2", "본인을 호감상대로 추가할 수 없습니다.");
+        }
+
+        // 액터가 생성한 '좋아요' 가져오기
+        List<LikeablePerson> fromLikeablePeople = fromInstaMember.getFromLikeablePeople();
+
+        LikeablePerson fromLikeablePerson = fromLikeablePeople.stream()
+                .filter(e -> e.getToInstaMember().getUsername().equals(username))
+                .findFirst()
+                .orElse(null);
+
+        if (fromLikeablePerson != null && fromLikeablePerson.getAttractiveTypeCode() == attractiveTypeCode){
+            return RsData.of("F-3", "이미 %s님에 대해서 호감표시를 했습니다.".formatted(username));
+        }
+
+        long likeablePersonFromMax = AppConfig.getLikeablePersonFromMax();
+
+        if ( fromLikeablePeople.size() >= likeablePersonFromMax){
+            return RsData.of("F-4", "최대 %d명에 대해서만 호감표시가 가능합니다.".formatted(likeablePersonFromMax));
+        }
+
+        if (fromLikeablePerson != null){
+            return RsData.of("F-2", "%님에 대해서 호감표시가 가능합니다.".formatted(username));
+        }
+
+        return RsData.of("S-1", "%s님에 대해서 호감표시가 가능합니다.".formatted(username));
+
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
@@ -1,8 +1,10 @@
 package com.ll.gramgram.boundedContext.member.entity;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,21 +17,15 @@ import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-@Builder // Member.builder().providerTypeCode(providerTypeCode) .. 이런식으로 쓸 수 있게 해주는
+@SuperBuilder // Member.builder().providerTypeCode(providerTypeCode) .. 이런식으로 쓸 수 있게 해주는
 @NoArgsConstructor // @Builder 붙이면 이거 필수
 @AllArgsConstructor // @Builder 붙이면 이거 필수
 @EntityListeners(AuditingEntityListener.class) // @CreatedDate, @LastModifiedDate 작동하게 허용
-@ToString // 디버그를 위한
+@ToString(callSuper = true) // 디버그를 위한
 @Entity // 아래 클래스는 member 테이블과 대응되고, 아래 클래스의 객체는 테이블의 row와 대응된다.
 @Getter // 아래 필드에 대해서 전부다 게터를 만든다. private Long id; => public Long getId() { ... }
-public class Member {
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    private Long id;
-    @CreatedDate // 아래 칼럼에는 값이 자동으로 들어간다.(INSERT 할 때)
-    private LocalDateTime createDate;
-    @LastModifiedDate // 아래 칼럼에는 값이 자동으로 들어간다.(UPDATE 할 때 마다)
-    private LocalDateTime modifyDate;
+public class Member extends BaseEntity {
+
     private String providerTypeCode; // 일반회원인지, 카카오로 가입한 회원인지, 구글로 가입한 회원인지
     @Column(unique = true)
     private String username;

--- a/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/member/entity/Member.java
@@ -34,7 +34,7 @@ public class Member {
     @Column(unique = true)
     private String username;
     private String password;
-    @OneToOne // 1:1
+    @OneToOne(fetch = FetchType.LAZY) // 1:1
     @Setter // memberService::updateInstaMember 함수 때문에
     private InstaMember instaMember;
 

--- a/src/main/resources/templates/usr/instaMember/connect.html
+++ b/src/main/resources/templates/usr/instaMember/connect.html
@@ -40,7 +40,7 @@
     <form th:action method="POST" class="p-10 max-w-sm flex flex-col gap-4"
           onsubmit="ConnectForm__submit(this); return false;">
         <div>
-            <input type="text" name="username" autocomplete="off" maxlength="30" placeholder="인스타그램 아이디"
+            <input type="text" name="username" maxlength="30" placeholder="인스타그램 아이디"
                    class="input input-bordered">
         </div>
         <div>

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -40,7 +40,8 @@
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
     <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
-    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}" th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
+    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}"
+          th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>
@@ -65,7 +66,7 @@
         if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
             toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
             localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
-        } else if ( !document.referrer ) {
+        } else if (!document.referrer) {
             const localStorageKeyAboutHistoryBackErrorMsg = "historyBackErrorMsg___null";
 
             if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {

--- a/src/main/resources/templates/usr/likeablePerson/add.html
+++ b/src/main/resources/templates/usr/likeablePerson/add.html
@@ -60,7 +60,7 @@
                 당신의 인스타ID : <span class="badge" th:text="${@rq.member.instaMember.username}"></span>
             </div>
             <div>
-                <input type="text" name="username" autocomplete="off" maxlength="30" placeholder="상대방의 인스타그램 아이디"
+                <input type="text" name="username" maxlength="30" placeholder="상대방의 인스타그램 아이디"
                        class="input input-bordered">
             </div>
             <div>

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -67,7 +67,7 @@
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/naver">
-            네이버 로그인하기(아직 안됨)
+            네이버 로그인하기
         </a>
     </div>
 </main>

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -127,7 +127,7 @@ public class LikeablePersonControllerTests {
 
     @Test
     @DisplayName("호감목록")
-    @WithUserDetails("KAKAO__2733187710")
+    @WithUserDetails("user3")
     void t005() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
@@ -140,22 +140,23 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().methodName("showList"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string(containsString("""
-                        <span class="toInstaMember_username">bw1111</span>
+                        <span class="toInstaMember_username">insta_user4</span>
                         """.stripIndent().trim())))
                 .andExpect(content().string(containsString("""
                         <span class="toInstaMember_attractiveTypeDisplayName">외모</span>
                         """.stripIndent().trim())))
                 .andExpect(content().string(containsString("""
-                        <span class="toInstaMember_username">bw2222</span>
+                        <span class="toInstaMember_username">insta_user100</span>
                         """.stripIndent().trim())))
                 .andExpect(content().string(containsString("""
                         <span class="toInstaMember_attractiveTypeDisplayName">성격</span>
                         """.stripIndent().trim())));
+        ;
     }
 
     @Test
-    @DisplayName("호감 삭제")
-    @WithUserDetails("KAKAO__2733187710")
+    @DisplayName("호감삭제")
+    @WithUserDetails("user3")
     void t006() throws Exception {
         // WHEN
         ResultActions resultActions = mvc
@@ -170,7 +171,8 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().handlerType(LikeablePersonController.class))
                 .andExpect(handler().methodName("delete"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("/likeablePerson/list**"));
+                .andExpect(redirectedUrlPattern("/likeablePerson/list**"))
+        ;
 
         assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
     }
@@ -215,5 +217,89 @@ public class LikeablePersonControllerTests {
         ;
 
         assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("인스타아이디가 없는 회원은 대해서 호감표시를 할 수 없다.")
+    @WithUserDetails("user1")
+    void t009() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user4")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
+    }
+
+    @Test
+    @DisplayName("본인이 본인에게 호감표시하면 안된다.")
+    @WithUserDetails("user3")
+    void t010() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user3")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
+    }
+
+    @Test
+    @DisplayName("특정인에 대해서 호감표시를 중복으로 시도하면 안된다.")
+    @WithUserDetails("user3")
+    void t011() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user4")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
+    }
+
+    @Test
+    @DisplayName("한 회원은 호감표시를 할 수 있는 최대 인원이 정해져 있다.")
+    @WithUserDetails("user5")
+    void t012() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user111")
+                        .param("attractiveTypeCode", "1")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is4xxClientError());
+        ;
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -1,6 +1,7 @@
 package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -301,5 +304,34 @@ public class LikeablePersonControllerTests {
                 .andExpect(handler().methodName("add"))
                 .andExpect(status().is4xxClientError());
         ;
+    }
+
+    @Test
+    @DisplayName("기존에 호감을 표시한 유저에게 새로운 사유로 호감을 표시하면 추가가 아니라 수정이 된다.")
+    @WithUserDetails("user3")
+    void t013() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(post("/likeablePerson/add")
+                        .with(csrf()) // CSRF 키 생성
+                        .param("username", "insta_user4")
+                        .param("attractiveTypeCode", "2")
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("add"))
+                .andExpect(status().is3xxRedirection());
+        ;
+
+        Optional<LikeablePerson> opLikeablePerson = likeablePersonService.findByFromInstaMember_usernameAndToInstaMember_username("insta_user3", "insta_user4");
+
+        int newAttractiveTypeCode = opLikeablePerson
+                .map(LikeablePerson::getAttractiveTypeCode)
+                .orElse(-1);
+
+        assertThat(newAttractiveTypeCode).isEqualTo(2);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -43,7 +43,7 @@ public class LikeablePersonServiceTests {
         WHERE id = 2;
         */
         InstaMember instaMemberInstaUser3 = likeablePersonId2.getFromInstaMember();
-        assertThat(instaMemberInstaUser3.getUsername()).isEqualTo("bw1611");
+        assertThat(instaMemberInstaUser3.getUsername()).isEqualTo("insta_user3");
 
         // 인스타아이디가 insta_user3 인 사람이 호감을 표시한 `좋아요` 목록
         // 좋아요는 2가지로 구성되어 있다 : from(호감표시자), to(호감받은자)
@@ -80,7 +80,7 @@ public class LikeablePersonServiceTests {
         WHERE id = 2;
         */
         InstaMember instaMemberInstaUser3 = likeablePersonId2.getFromInstaMember();
-        assertThat(instaMemberInstaUser3.getUsername()).isEqualTo("bw1611");
+        assertThat(instaMemberInstaUser3.getUsername()).isEqualTo("insta_user3");
 
         // 내가 새로 호감을 표시하려는 사람의 인스타 아이디
         String usernameToLike = "insta_user4";
@@ -143,6 +143,21 @@ public class LikeablePersonServiceTests {
     @Test
     @DisplayName("테스트 4")
     void t004() throws Exception {
+        // 좋아하는 사람이 2번 인스타 회원인 `좋아요` 검색
+        /*
+        SELECT l1_0.id,
+        l1_0.attractive_type_code,
+        l1_0.create_date,
+        l1_0.from_insta_member_id,
+        l1_0.from_insta_member_username,
+        l1_0.modify_date,
+        l1_0.to_insta_member_id,
+        l1_0.to_insta_member_username
+        FROM likeable_person l1_0
+        WHERE l1_0.from_insta_member_id = 2
+        */
+        List<LikeablePerson> likeablePeople = likeablePersonRepository.findByFromInstaMemberId(2L);
+
         // 좋아하는 대상의 아이디가 insta_user100 인 `좋아요`들 만 검색
         /*
         SELECT l1_0.id,
@@ -158,7 +173,7 @@ public class LikeablePersonServiceTests {
         ON t1_0.id=l1_0.to_insta_member_id
         WHERE t1_0.username = "insta_user100";
         */
-        List<LikeablePerson> likeablePeople2 = likeablePersonRepository.findByToInstaMember_username("bw2222");
+        List<LikeablePerson> likeablePeople2 = likeablePersonRepository.findByToInstaMember_username("insta_user100");
 
         assertThat(likeablePeople2.get(0).getId()).isEqualTo(2);
 
@@ -178,8 +193,8 @@ public class LikeablePersonServiceTests {
         WHERE l1_0.from_insta_member_id = 2
         AND t1_0.username = "insta_user100";
         */
-        LikeablePerson likeablePerson = likeablePersonRepository.findByFromInstaMember_usernameAndToInstaMember_username("bw2222", "bw1611");
+        LikeablePerson likeablePerson = likeablePersonRepository.findByFromInstaMemberIdAndToInstaMember_username(2L, "insta_user100");
 
-        assertThat(likeablePerson.getId()).isEqualTo(10);
+        assertThat(likeablePerson.getId()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -197,4 +197,12 @@ public class LikeablePersonServiceTests {
 
         assertThat(likeablePerson.getId()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("테스트 5")
+    void t005() throws Exception {
+        LikeablePerson likeablePerson = likeablePersonRepository.findQslByFromInstaMemberIdAndToInstaMember_username(2L, "insta_user4").orElse(null);
+
+        assertThat(likeablePerson.getId()).isEqualTo(1L);
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -139,4 +139,47 @@ public class LikeablePersonServiceTests {
 
         assertThat(likeablePersonFromMax).isEqualTo(10);
     }
+
+    @Test
+    @DisplayName("테스트 4")
+    void t004() throws Exception {
+        // 좋아하는 대상의 아이디가 insta_user100 인 `좋아요`들 만 검색
+        /*
+        SELECT l1_0.id,
+        l1_0.attractive_type_code,
+        l1_0.create_date,
+        l1_0.from_insta_member_id,
+        l1_0.from_insta_member_username,
+        l1_0.modify_date,
+        l1_0.to_insta_member_id,
+        l1_0.to_insta_member_username
+        FROM likeable_person l1_0
+        LEFT JOIN insta_member t1_0
+        ON t1_0.id=l1_0.to_insta_member_id
+        WHERE t1_0.username = "insta_user100";
+        */
+        List<LikeablePerson> likeablePeople2 = likeablePersonRepository.findByToInstaMember_username("bw2222");
+
+        assertThat(likeablePeople2.get(0).getId()).isEqualTo(2);
+
+        // 좋아하는 사람이 2번 인스타 회원이고, 좋아하는 대상의 인스타아이디가 "insta_user100" 인 `좋아요`
+        /*
+        SELECT l1_0.id,
+        l1_0.attractive_type_code,
+        l1_0.create_date,
+        l1_0.from_insta_member_id,
+        l1_0.from_insta_member_username,
+        l1_0.modify_date,
+        l1_0.to_insta_member_id,
+        l1_0.to_insta_member_username
+        FROM likeable_person l1_0
+        LEFT JOIN insta_member t1_0
+        ON t1_0.id=l1_0.to_insta_member_id
+        WHERE l1_0.from_insta_member_id = 2
+        AND t1_0.username = "insta_user100";
+        */
+        LikeablePerson likeablePerson = likeablePersonRepository.findByFromInstaMember_usernameAndToInstaMember_username("bw2222", "bw1611");
+
+        assertThat(likeablePerson.getId()).isEqualTo(10);
+    }
 }


### PR DESCRIPTION
### [리팩토링]
- [x] setter를 이용한 의존성 주입방법은 단점이 많기 떄문에 getter만 이용하여 할 수 있도록 수정해준다.
- [x] 현재는 case 6을 진행하면서 case 4를 사용하지 않게되었는데 AttractiveTypeCode를 이용하여 case 4를 활성화 해준다. 즉 같은 유형의 좋아요가 들어왔을 경우 case 4가 실행되게 해준다.
- [x] 현재 LikeablePseson의 like() 메서드가 너무 많은 것을 처리하여 수정 필요
- [x] member.getInstaMember().getFromLikeablePeople().size() >= 10 하드코딩된 것을 yml파일로 이동
- [x] ServiceTest 작성
- [x] N + 1 문제 해결
- [x] fetch타입을 Eager에서 Lazy로 수정
- [ ] html파일 UI 수정

### [특이사항]
- Setter를 사용하면 왜 안좋을까?
  - 이유는 간단하다. Setter 메서드를 사용하면 값을 변경한 의도를 파악하기 힘들며 객체의 일관성을 유지하기 어렵기 때문이 대표적이다. 물론 그 외에도 다른 많은 단점들이 있겠지만 이정도만 해도 이유는 충분하다.