### PR TITLE
Mission_4Week

### DIFF
--- a/records/4Week.LeeBuWon.md
+++ b/records/4Week.LeeBuWon.md
@@ -4,8 +4,8 @@
   - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
 - [ ] 배포 (필수미션)
   - [ ] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
-- [ ] likeablePerson (선택미션)
-  - [ ] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
+- [x] likeablePerson (선택미션)
+  - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
   - [ ] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
 
 ---
@@ -14,18 +14,21 @@
 
 ### [해결 방법]
 
-- [x] likeablePerson (필수미션)
-  - 1, @RequestParam(name = "gender", defaultValue = "") String gender 통해 option에서 gender가 W / M 인지 받아온다.
-  - 2, if (gender.equals("W") || gender.equals("M")) 을 통해 참이라면 likeablePersonService.filterGender(likeablePeople, gender); 로 들어간다.
-  - 3, likeablePeople.stream()의 filter를 통해 들어온 gender랑 getFromInstaMember().getGender()가 같은것만 가져온다.
- 
 ### 필수미션
 
-- 1, 
+- [x] likeablePerson (필수미션)
+  - 1, @RequestParam(name = "gender", defaultValue = "") String gender 통해 option에서 gender가 W / M 인지 받아온다.
+  - 2, if (gender.equals("W") || gender.equals("M")) 을 통해 참이라면 likeablePersonService.filterGender(likeablePeople, gender) 로 service에 들어간다.
+  - 3, likeablePeople.stream()의 filter를 통해 들어온 gender랑 getFromInstaMember().getGender()가 같은것만 가져온다.
 
 ### 선택미션
 
-- 1,
+- [x] likeablePerson (선택미션)
+  - 1, @RequestParam(name = "attractiveTypeCode", defaultValue = "") String attractiveTypeCode 통해 option에서 attractiveTypeCode가 1 / 2 / 3 인지 받아온다.
+  - 2,  if (!attractiveTypeCode.isEmpty()) 을 통해 Empty상태가 아니라면 likeablePersonService.filterAttractiveTypeCode(likeablePeople, attractiveTypeCode) 로 service에 들어간다.
+  - 3, likeablePerson에 attractiveTypeCode는 int형으로 되있으니 @RequestParam을 통해 String으로 받아온 것을 Integer.parseInt를 통해 int형으로 변환해준다.
+  - 4, filter(p -> p.getAttractiveTypeCode() == toAttractiveTypeCode)를 통해 알맞은 값을 가지고 온다.
+
 
 ### [리팩토링]
 - [ ] 

--- a/records/4Week.LeeBuWon.md
+++ b/records/4Week.LeeBuWon.md
@@ -33,6 +33,7 @@
 
 
 ### [수정해야할 부분]
+- [x] 수정완료 ( .thenComparing(Comparator.comparing(BaseEntity::getCreateDate).reversed())) )
 - 현재 선택미션2번의 6번이 글이 최신순으로 나오지 않는다. likeablePeople.stream()
   .sorted(Comparator.comparingInt(LikeablePerson::getAttractiveTypeCode)
   .thenComparing(BaseEntity::getCreateDate)) 에서 reverse()를 해놓으면 AttractiveTypeCode까지 정렬이 잘못되기 때문에 아직 해결하지 못하였다.

--- a/records/4Week.LeeBuWon.md
+++ b/records/4Week.LeeBuWon.md
@@ -1,0 +1,31 @@
+## 체크리스트
+
+- [x] likeablePerson (필수미션)
+  - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
+- [ ] 배포 (필수미션)
+  - [ ] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
+- [ ] likeablePerson (선택미션)
+  - [ ] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
+  - [ ] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+
+---
+
+## 4주차 미션 요약
+
+### [해결 방법]
+
+- [x] likeablePerson (필수미션)
+  - 1, @RequestParam(name = "gender", defaultValue = "") String gender 통해 option에서 gender가 W / M 인지 받아온다.
+  - 2, if (gender.equals("W") || gender.equals("M")) 을 통해 참이라면 likeablePersonService.filterGender(likeablePeople, gender); 로 들어간다.
+  - 3, likeablePeople.stream()의 filter를 통해 들어온 gender랑 getFromInstaMember().getGender()가 같은것만 가져온다.
+ 
+### 필수미션
+
+- 1, 
+
+### 선택미션
+
+- 1,
+
+### [리팩토링]
+- [ ] 

--- a/records/4Week.LeeBuWon.md
+++ b/records/4Week.LeeBuWon.md
@@ -6,7 +6,7 @@
   - [ ] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
 - [x] likeablePerson (선택미션)
   - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
-  - [ ] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+  - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
 
 ---
 
@@ -16,19 +16,26 @@
 
 ### 필수미션
 
-- [x] likeablePerson (필수미션)
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현 (필수미션)
   - 1, @RequestParam(name = "gender", defaultValue = "") String gender 통해 option에서 gender가 W / M 인지 받아온다.
   - 2, if (gender.equals("W") || gender.equals("M")) 을 통해 참이라면 likeablePersonService.filterGender(likeablePeople, gender) 로 service에 들어간다.
   - 3, likeablePeople.stream()의 filter를 통해 들어온 gender랑 getFromInstaMember().getGender()가 같은것만 가져온다.
 
 ### 선택미션
 
-- [x] likeablePerson (선택미션)
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현 (선택미션)
   - 1, @RequestParam(name = "attractiveTypeCode", defaultValue = "") String attractiveTypeCode 통해 option에서 attractiveTypeCode가 1 / 2 / 3 인지 받아온다.
   - 2,  if (!attractiveTypeCode.isEmpty()) 을 통해 Empty상태가 아니라면 likeablePersonService.filterAttractiveTypeCode(likeablePeople, attractiveTypeCode) 로 service에 들어간다.
   - 3, likeablePerson에 attractiveTypeCode는 int형으로 되있으니 @RequestParam을 통해 String으로 받아온 것을 Integer.parseInt를 통해 int형으로 변환해준다.
   - 4, filter(p -> p.getAttractiveTypeCode() == toAttractiveTypeCode)를 통해 알맞은 값을 가지고 온다.
 
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능 (선택미션)
+
+
+### [수정해야할 부분]
+- 현재 선택미션2번의 6번이 글이 최신순으로 나오지 않는다. likeablePeople.stream()
+  .sorted(Comparator.comparingInt(LikeablePerson::getAttractiveTypeCode)
+  .thenComparing(BaseEntity::getCreateDate)) 에서 reverse()를 해놓으면 AttractiveTypeCode까지 정렬이 잘못되기 때문에 아직 해결하지 못하였다.
 
 ### [리팩토링]
 - [ ] 

--- a/src/main/java/com/ll/gramgram/base/i18nCOnfig/CustomMessageSource.java
+++ b/src/main/java/com/ll/gramgram/base/i18nCOnfig/CustomMessageSource.java
@@ -1,6 +1,8 @@
 package com.ll.gramgram.base.i18nCOnfig;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +12,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Component
+@RequiredArgsConstructor
 public class CustomMessageSource extends ResourceBundleMessageSource {
+    private final ApplicationContext applicationContext;
+    private CustomMessageSource customMessageSource;
+
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\[\\[(.+?)\\]\\]");
 
     @Override
@@ -27,8 +33,21 @@ public class CustomMessageSource extends ResourceBundleMessageSource {
         return replaceVariables(super.resolveCode(code, locale), locale);
     }
 
-    @Cacheable(cacheNames = "translation", key = "#code + ',' + #locale")
     public String replaceVariablesToString(String code, Locale locale) {
+        // @Cacheable 이 붙어있는 메서드는 원래 this 로 호출하면 캐시가 작동하지 않는다.
+        // 그래서 프록시 객체를 꺼내서 해야한다.
+        // this. 으로 호출하면 안된다.
+        if (customMessageSource == null) {
+            customMessageSource = applicationContext.getBean("customMessageSource", CustomMessageSource.class);
+        }
+
+        return customMessageSource._replaceVariablesToString(code, locale);
+    }
+
+    @Cacheable(cacheNames = "translation", key = "#code + ',' + #locale")
+    public String _replaceVariablesToString(String code, Locale locale) {
+        System.out.println("code : " + code + ", locale : " + locale);
+
         StringBuilder result = new StringBuilder();
         Matcher matcher = VARIABLE_PATTERN.matcher(code);
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -128,7 +128,8 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(@RequestParam(name = "gender", defaultValue = "") String gender, Model model) {
+    public String showToList(@RequestParam(name = "gender", defaultValue = "") String gender,
+                             @RequestParam(name = "attractiveTypeCode", defaultValue = "") String attractiveTypeCode, Model model) {
         //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
         InstaMember instaMember = rq.getMember().getInstaMember();
 
@@ -141,6 +142,11 @@ public class LikeablePersonController {
             // @RequestParam을 통해 gender에서 W / M 을 받아 온다.
             if (gender.equals("W") || gender.equals("M")){
                 likeablePeople = likeablePersonService.filterGender(likeablePeople, gender);
+            }
+
+            log.info("attractiveTypeCode = {} ", attractiveTypeCode);
+            if (!attractiveTypeCode.isEmpty()){
+                likeablePeople = likeablePersonService.filterAttractiveTypeCode(likeablePeople, attractiveTypeCode);
             }
 
             model.addAttribute("likeablePeople", likeablePeople);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -128,14 +128,21 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model) {
-        //TODO : 필수미션
+    public String showToList(@RequestParam(name = "gender", defaultValue = "") String gender, Model model) {
+        //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
             List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
+            log.info("gender = {}", gender);
+
+            // @RequestParam을 통해 gender에서 W / M 을 받아 온다.
+            if (gender.equals("W") || gender.equals("M")){
+                likeablePeople = likeablePersonService.filterGender(likeablePeople, gender);
+            }
+
             model.addAttribute("likeablePeople", likeablePeople);
         }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -129,24 +129,32 @@ public class LikeablePersonController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
     public String showToList(@RequestParam(name = "gender", defaultValue = "") String gender,
-                             @RequestParam(name = "attractiveTypeCode", defaultValue = "") String attractiveTypeCode, Model model) {
-        //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
+                             @RequestParam(name = "attractiveTypeCode", defaultValue = "") String attractiveTypeCode,
+                             @RequestParam(name = "sortCode", defaultValue = "1") String sortCode,
+                             Model model) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
             List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
-            log.info("gender = {}", gender);
 
-            // @RequestParam을 통해 gender에서 W / M 을 받아 온다.
+            //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
+            log.info("gender = {}", gender);
             if (gender.equals("W") || gender.equals("M")){
                 likeablePeople = likeablePersonService.filterGender(likeablePeople, gender);
             }
 
+            //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
             log.info("attractiveTypeCode = {} ", attractiveTypeCode);
             if (!attractiveTypeCode.isEmpty()){
                 likeablePeople = likeablePersonService.filterAttractiveTypeCode(likeablePeople, attractiveTypeCode);
+            }
+
+            //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+            log.info("sortCode = {} ", sortCode);
+            if (!sortCode.isEmpty()){
+                likeablePeople = likeablePersonService.filterSort(likeablePeople, sortCode);
             }
 
             model.addAttribute("likeablePeople", likeablePeople);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -336,7 +336,7 @@ public class LikeablePersonService {
         if (toSortCode == 6){
             List<LikeablePerson> filterSortCode = likeablePeople.stream()
                     .sorted(Comparator.comparingInt(LikeablePerson::getAttractiveTypeCode)
-                            .thenComparing(BaseEntity::getCreateDate))
+                            .thenComparing(Comparator.comparing(BaseEntity::getCreateDate).reversed()))
                     .collect(Collectors.toList());
 
             return filterSortCode;

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -263,4 +264,13 @@ public class LikeablePersonService {
 
         return RsData.of("S-1", "수정 가능합니다.");
     }
+
+    public List<LikeablePerson> filterGender(List<LikeablePerson> likeablePeople, String gender) {
+        List<LikeablePerson> filterOption = likeablePeople.stream()
+                .filter(p -> p.getFromInstaMember().getGender().equals(gender))
+                .collect(Collectors.toList());
+
+        return filterOption;
+    }
 }
+

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -267,6 +267,7 @@ public class LikeablePersonService {
         return RsData.of("S-1", "수정 가능합니다.");
     }
 
+    //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현 (필수미션)
     public List<LikeablePerson> filterGender(List<LikeablePerson> likeablePeople, String gender) {
         List<LikeablePerson> filterGender = likeablePeople.stream()
                 .filter(p -> p.getFromInstaMember().getGender().equals(gender))
@@ -275,6 +276,7 @@ public class LikeablePersonService {
         return filterGender;
     }
 
+    //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현 (선택미션)
     public List<LikeablePerson> filterAttractiveTypeCode(List<LikeablePerson> likeablePeople, String attractiveTypeCode) {
         int toAttractiveTypeCode = Integer.parseInt(attractiveTypeCode);
 
@@ -288,20 +290,11 @@ public class LikeablePersonService {
     //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
     public List<LikeablePerson> filterSort(List<LikeablePerson> likeablePeople, String sortCode) {
         int toSortCode = Integer.parseInt(sortCode);
-
-        if (toSortCode == 1){
-            List<LikeablePerson> filterSortCode = likeablePeople.stream()
-                    .sorted(Comparator.comparing(LikeablePerson::getCreateDate).reversed())
-                    .collect(Collectors.toList());
-
-            log.info("filterSortCode = {}", filterSortCode);
-
-            return filterSortCode;
-        }
+        log.info("toSortCode = {}", sortCode);
 
         if (toSortCode == 2){
             List<LikeablePerson> filterSortCode = likeablePeople.stream()
-                    .sorted(Comparator.comparing(BaseEntity::getCreateDate))
+                    .sorted(Comparator.comparing(LikeablePerson::getCreateDate))
                     .collect(Collectors.toList());
 
             log.info("filterSortCode = {}", filterSortCode);
@@ -330,14 +323,34 @@ public class LikeablePersonService {
         }
 
         if (toSortCode == 5){
+            List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                    .sorted(Comparator.comparing((LikeablePerson likeablePerson) -> likeablePerson.getFromInstaMember().getGender().equals("W") ? 1 : 0)
+                            .thenComparing(LikeablePerson::getCreateDate).reversed())
+                    .collect(Collectors.toList());
 
+            log.info("filterSortCode = {}", filterSortCode);
+
+            return filterSortCode;
         }
 
         if (toSortCode == 6){
+            List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                    .sorted(Comparator.comparingInt(LikeablePerson::getAttractiveTypeCode)
+                            .thenComparing(BaseEntity::getCreateDate))
+                    .collect(Collectors.toList());
 
+            return filterSortCode;
         }
 
-        return null;
+        // default 1이 넘어오니깐 따로 if문을 설정해주지 않았다.
+        List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                .sorted(Comparator.comparing(LikeablePerson::getCreateDate).reversed())
+                .collect(Collectors.toList());
+
+        log.info("filterSortCode = {}", filterSortCode);
+
+        return filterSortCode;
+
     }
 }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -266,11 +266,21 @@ public class LikeablePersonService {
     }
 
     public List<LikeablePerson> filterGender(List<LikeablePerson> likeablePeople, String gender) {
-        List<LikeablePerson> filterOption = likeablePeople.stream()
+        List<LikeablePerson> filterGender = likeablePeople.stream()
                 .filter(p -> p.getFromInstaMember().getGender().equals(gender))
                 .collect(Collectors.toList());
 
-        return filterOption;
+        return filterGender;
+    }
+
+    public List<LikeablePerson> filterAttractiveTypeCode(List<LikeablePerson> likeablePeople, String attractiveTypeCode) {
+        int toAttractiveTypeCode = Integer.parseInt(attractiveTypeCode);
+
+        List<LikeablePerson> filterAttractiveTypeCode = likeablePeople.stream()
+                .filter(p -> p.getAttractiveTypeCode() == toAttractiveTypeCode)
+                .collect(Collectors.toList());
+
+        return filterAttractiveTypeCode;
     }
 }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.likeablePerson.service;
 
+import com.ll.gramgram.base.BaseEntity;
 import com.ll.gramgram.base.appconfig.AppConfig;
 import com.ll.gramgram.base.event.EventAfterLike;
 import com.ll.gramgram.base.event.EventAfterModifyAttractiveType;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -281,6 +283,61 @@ public class LikeablePersonService {
                 .collect(Collectors.toList());
 
         return filterAttractiveTypeCode;
+    }
+
+    //TODO : 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+    public List<LikeablePerson> filterSort(List<LikeablePerson> likeablePeople, String sortCode) {
+        int toSortCode = Integer.parseInt(sortCode);
+
+        if (toSortCode == 1){
+            List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                    .sorted(Comparator.comparing(LikeablePerson::getCreateDate).reversed())
+                    .collect(Collectors.toList());
+
+            log.info("filterSortCode = {}", filterSortCode);
+
+            return filterSortCode;
+        }
+
+        if (toSortCode == 2){
+            List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                    .sorted(Comparator.comparing(BaseEntity::getCreateDate))
+                    .collect(Collectors.toList());
+
+            log.info("filterSortCode = {}", filterSortCode);
+
+            return filterSortCode;
+        }
+
+        if (toSortCode == 3){
+            List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                    .sorted(Comparator.comparing((LikeablePerson likeablePerson) -> likeablePerson.getFromInstaMember().getToLikeablePeople().size()).reversed())
+                    .collect(Collectors.toList());
+
+            log.info("filterSortCode = {}", filterSortCode);
+
+            return filterSortCode;
+        }
+
+        if (toSortCode == 4){
+            List<LikeablePerson> filterSortCode = likeablePeople.stream()
+                    .sorted(Comparator.comparing((LikeablePerson likeablePerson) -> likeablePerson.getFromInstaMember().getToLikeablePeople().size()))
+                    .collect(Collectors.toList());
+
+            log.info("filterSortCode = {}", filterSortCode);
+
+            return filterSortCode;
+        }
+
+        if (toSortCode == 5){
+
+        }
+
+        if (toSortCode == 6){
+
+        }
+
+        return null;
     }
 }
 

--- a/src/main/resources/templates/usr/likeablePerson/toList.html
+++ b/src/main/resources/templates/usr/likeablePerson/toList.html
@@ -25,10 +25,10 @@
           <form class="flex flex-col gap-6">
             <div class="form-control">
               <label class="label">
-                                <span class="label-text">
-                                    <i class="fa-solid fa-person-half-dress"></i>
-                                    성별
-                                </span>
+                <span class="label-text">
+                  <i class="fa-solid fa-person-half-dress"></i>
+                  성별
+                </span>
               </label>
               <select name="gender" class="select select-bordered w-full"
                       onchange="$(this).closest('form').submit();">
@@ -45,10 +45,10 @@
 
             <div class="form-control">
               <label class="label">
-                                <span class="label-text">
-                                    <i class="fa-solid fa-check"></i>
-                                    호감사유
-                                </span>
+                <span class="label-text">
+                  <i class="fa-solid fa-check"></i>
+                  호감사유
+                </span>
               </label>
               <select name="attractiveTypeCode" class="select select-bordered w-full"
                       onchange="$(this).closest('form').submit();">
@@ -66,10 +66,10 @@
 
             <div class="form-control">
               <label class="label">
-                                <span class="label-text">
-                                    <i class="fa-solid fa-arrow-up-z-a"></i>
-                                    정렬
-                                </span>
+                <span class="label-text">
+                  <i class="fa-solid fa-arrow-up-z-a"></i>
+                  정렬
+                </span>
               </label>
               <select name="sortCode" class="select select-bordered w-full"
                       onchange="$(this).closest('form').submit();">
@@ -109,8 +109,7 @@
                   호감표시
                 </div>
                 <div class="mt-2">
-                                    <span class="badge badge-primary"
-                                          th:text="${#temporals.format(likeablePerson.createDate, 'yy.MM.dd HH:mm')}"></span>
+                  <span class="badge badge-primary" th:text="${#temporals.format(likeablePerson.createDate, 'yy.MM.dd HH:mm')}"></span>
                 </div>
               </div>
 
@@ -141,16 +140,16 @@
 
     <div class="text-center mt-4">
       <a th:if="${@rq.member.hasConnectedInstaMember}" href="like" class="btn btn-link">
-                <span>
-                    <i class="fa-solid fa-heart-circle-plus"></i>
-                    호감표시&nbsp;
-                </span>
+        <span>
+          <i class="fa-solid fa-heart-circle-plus"></i>
+          호감표시&nbsp;
+        </span>
       </a>
       <a th:if="${@rq.member.hasConnectedInstaMember}" href="/usr/member/me" class="btn btn-link">
-                <span>
-                    <i class="fa-solid fa-user mr-1"></i>
-                    내 정보&nbsp;
-                </span>
+        <span>
+          <i class="fa-solid fa-user mr-1"></i>
+          내 정보&nbsp;
+        </span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
## 체크리스트

- [x] likeablePerson (필수미션)
  - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
- [ ] 배포 (필수미션)
  - [ ] 네이버클라우드플랫폼을 통한 배포, 도메인, HTTPS 까지 적용
- [x] likeablePerson (선택미션)
  - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
  - [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능

---

## 4주차 미션 요약

### [해결 방법]

### 필수미션

- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현 (필수미션)
  - 1, @RequestParam(name = "gender", defaultValue = "") String gender 통해 option에서 gender가 W / M 인지 받아온다.
  - 2, if (gender.equals("W") || gender.equals("M")) 을 통해 참이라면 likeablePersonService.filterGender(likeablePeople, gender) 로 service에 들어간다.
  - 3, likeablePeople.stream()의 filter를 통해 들어온 gender랑 getFromInstaMember().getGender()가 같은것만 가져온다.

### 선택미션

- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현 (선택미션)
  - 1, @RequestParam(name = "attractiveTypeCode", defaultValue = "") String attractiveTypeCode 통해 option에서 attractiveTypeCode가 1 / 2 / 3 인지 받아온다.
  - 2,  if (!attractiveTypeCode.isEmpty()) 을 통해 Empty상태가 아니라면 likeablePersonService.filterAttractiveTypeCode(likeablePeople, attractiveTypeCode) 로 service에 들어간다.
  - 3, likeablePerson에 attractiveTypeCode는 int형으로 되있으니 @RequestParam을 통해 String으로 받아온 것을 Integer.parseInt를 통해 int형으로 변환해준다.
  - 4, filter(p -> p.getAttractiveTypeCode() == toAttractiveTypeCode)를 통해 알맞은 값을 가지고 온다.

- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능 (선택미션)


### [수정해야할 부분]
- 현재 선택미션2번의 6번이 글이 최신순으로 나오지 않는다. likeablePeople.stream()
  .sorted(Comparator.comparingInt(LikeablePerson::getAttractiveTypeCode)
  .thenComparing(BaseEntity::getCreateDate)) 에서 reverse()를 해놓으면 AttractiveTypeCode까지 정렬이 잘못되기 때문에 아직 해결하지 못하였다.

### [리팩토링]
- [ ] 